### PR TITLE
feat: adds vale linter to image

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,13 @@ Multiple images can be built with a single command by listing each of their dire
 
 To build multi architecture images:
 * Use `docker login` to log into dockerhub as `farmdata2`.
-* Use the commands as above but omit the `-d` flag.
+* Use the commands as above but:
+  - omit the `-d` flag.
+  - add the `-p` flag.
+  
+```
+./build-images.bash -p fd2dev
+```
 
 Notes:
 * Logging in to dockerhub as `farmdata2` requires authentication that is available only to project maintainers.

--- a/build-images.bash
+++ b/build-images.bash
@@ -9,7 +9,7 @@ PLATFORMS=linux/amd64,linux/arm64
 # Check for the local build flag -d
 LOCAL_BUILD=0
 getopts 'd' opt 2> /dev/null
-if [ $opt == 'd' ];
+if [ "$opt" == 'd' ];
 then 
   LOCAL_BUILD=1
   shift
@@ -24,37 +24,36 @@ then
   exit 255
 fi
 
-# Only check the login and make the builder if we are pushing the images.
+# Only check the login if we are pushing the images.
 if [ $LOCAL_BUILD == 0 ];
 then
-
-    # Check that the DockerHub user identified above is logged in.
-    LOGGED_IN=$(docker-credential-desktop list | grep "$DOCKER_HUB_USER" | wc -l | cut -f 8 -d ' ')
-    if [ "$LOGGED_IN" == "0" ];
-    then
-        echo "Please log into Docker Hub as $DOCKER_HUB_USER before building images."
-        echo "  Use: docker login"
-        echo "This allows multi architecture images to be pushed."
-        exit 255
-    fi
-
-    # Create the builder if it doesn't exist.
-    FD2_BUILDER=$(docker buildx ls | grep "fd2builder" | wc -l | cut -f 8 -d ' ')
-    if [ "$FD2_BUILDER" == "0" ];
-    then
-        echo "Making new builder for FarmData2 images."
-        docker buildx create --name fd2builder
-    fi
-
-    # Switch to use the fd2builder.
-    echo "Using the fd2bilder."
-    docker buildx use fd2builder
+  # Check that the DockerHub user identified above is logged in.
+  LOGGED_IN=$(docker-credential-desktop list | grep "$DOCKER_HUB_USER" | wc -l | cut -f 8 -d ' ')
+  if [ "$LOGGED_IN" == "0" ];
+  then
+    echo "Please log into Docker Hub as $DOCKER_HUB_USER before building images."
+    echo "  Use: docker login"
+    echo "This allows multi architecture images to be pushed."
+    exit 255
+  fi
 fi
+
+# Create the builder if it doesn't exist.
+FD2_BUILDER=$(docker buildx ls | grep "fd2builder" | wc -l | cut -f 8 -d ' ')
+if [ "$FD2_BUILDER" == "0" ];
+then
+  echo "Making new builder for FarmData2 images."
+  docker buildx create --name fd2builder
+fi
+
+# Switch to use the fd2builder.
+echo "Using the fd2bilder."
+docker buildx use fd2builder
 
 # Build and push each of the images to Docker Hub.
 for IMAGE in "$@"
 do
-  if [ ! -f $IMAGE/Dockerfile ] | [ ! -f $IMAGE/repo.txt ];
+  if [ ! -f "$IMAGE"/Dockerfile ] | [ ! -f "$IMAGE"/repo.txt ];
   then
     echo "Error: $IMAGE/Dockerfile or $IMAGE/repo.txt does not exit."
     echo "       Skipping $IMAGE"
@@ -76,10 +75,10 @@ do
     if [ $LOCAL_BUILD == 1 ];
     then
       echo "  Building image locally."
-      docker build  -t $REPO .
+      docker build -t "$REPO" .
     else
       echo "  Building multi architecture image and pushing to dockerhub."
-      docker buildx build --platform $PLATFORMS -t $REPO --push .
+      docker build --platform $PLATFORMS -t "$REPO" --push .
     fi
 
     if [ -f after.bash ];

--- a/build-images.bash
+++ b/build-images.bash
@@ -6,14 +6,16 @@
 DOCKER_HUB_USER="farmdata2"
 PLATFORMS=linux/amd64,linux/arm64
 
-# Check for the local build flag -d
 LOCAL_BUILD=0
-getopts 'd' opt 2> /dev/null
-if [ "$opt" == 'd' ];
-then 
-  LOCAL_BUILD=1
-  shift
-fi
+PUSH=0
+while getopts ":dp:" opt
+do
+  case $opt in
+    d) LOCAL_BUILD=1;;
+    p) PUSH=1;;
+    *) echo "Invalid option: -$opt";;
+  esac
+done
 
 if [ $# -lt 1 ];
 then
@@ -25,11 +27,17 @@ then
 fi
 
 # Only check the login if we are pushing the images.
-if [ $LOCAL_BUILD == 0 ];
+if [ "$LOCAL_BUILD" = "0" ] && [ "$PUSH" = "1" ];
 then
   # Check that the DockerHub user identified above is logged in.
-  LOGGED_IN=$(docker-credential-desktop list | grep "$DOCKER_HUB_USER" | wc -l | cut -f 8 -d ' ')
-  if [ "$LOGGED_IN" == "0" ];
+  if [ "$(which docker-credential-desktop)" != "" ];
+  then
+    LOGGED_IN=$(docker-credential-desktop list | grep "$DOCKER_HUB_USER" | wc -l | cut -f 8 -d ' ')
+  else
+    LOGGED_IN=$(docker system info | grep -E 'Username|Registry' | grep "$DOCKER_HUB_USER" | wc -l | cut -f 8 -d ' ')
+  fi
+
+  if [ "$LOGGED_IN" = "0" ];
   then
     echo "Please log into Docker Hub as $DOCKER_HUB_USER before building images."
     echo "  Use: docker login"
@@ -38,17 +46,20 @@ then
   fi
 fi
 
-# Create the builder if it doesn't exist.
-FD2_BUILDER=$(docker buildx ls | grep "fd2builder" | wc -l | cut -f 8 -d ' ')
-if [ "$FD2_BUILDER" == "0" ];
+if [ "$LOCAL_BUILD" = "0" ];
 then
-  echo "Making new builder for FarmData2 images."
-  docker buildx create --name fd2builder
-fi
+  # Create the builder if it doesn't exist.
+  FD2_BUILDER=$(docker buildx ls | grep "fd2builder" | wc -l | cut -f 8 -d ' ')
+  if [ "$FD2_BUILDER" = "0" ];
+  then
+    echo "Making new builder for FarmData2 images."
+    docker buildx create --name fd2builder
+  fi
 
-# Switch to use the fd2builder.
-echo "Using the fd2bilder."
-docker buildx use fd2builder
+  # Switch to use the fd2builder.
+  echo "Using the fd2bilder."
+  docker buildx use fd2builder
+fi
 
 # Build and push each of the images to Docker Hub.
 for IMAGE in "$@"
@@ -72,13 +83,17 @@ do
     REPO="$DOCKER_HUB_USER/$TAG"
     echo "  Performing docker build using tag $REPO ..."
 
-    if [ $LOCAL_BUILD == 1 ];
+    if [ "$LOCAL_BUILD" = "1" ];
     then
       echo "  Building image locally."
       docker build -t "$REPO" .
+    elif [ "$PUSH" = "0" ];
+    then
+      echo "  Building multi architecture image."
+      docker buildx build --platform "$PLATFORMS" -t "$REPO" .
     else
       echo "  Building multi architecture image and pushing to dockerhub."
-      docker build --platform $PLATFORMS -t "$REPO" --push .
+      docker buildx build --platform "$PLATFORMS" -t "$REPO" --push .
     fi
 
     if [ -f after.bash ];

--- a/fd2dev/Dockerfile
+++ b/fd2dev/Dockerfile
@@ -1,5 +1,8 @@
 FROM farmdata2/fd2-vnc-novnc-base:1.2.1
 
+# Username for the non-root user in the farmdata2/fd2-vnc-novnc-base container.
+ARG USERNAME=fd2dev
+
 USER root
 
 # Install some additional system software

--- a/fd2dev/Dockerfile
+++ b/fd2dev/Dockerfile
@@ -1,4 +1,4 @@
-FROM farmdata2/fd2-vnc-novnc-base:1.2.1
+FROM farmdata2/fd2-vnc-novnc-base:1.3.0
 
 # Username for the non-root user in the farmdata2/fd2-vnc-novnc-base container.
 ARG USERNAME=fd2dev
@@ -66,14 +66,18 @@ RUN ./umask.bash \
 USER fd2dev
 WORKDIR /home/fd2dev
 
+# Newer versions of VSCodium break the the ability to install
+# extensions in multi-architecture builds. So we don't do 
+# that anymore and rely on the .vscode/extensions.json to 
+# specify the extensions to install and then install those later.
+
 # Install some additional VSCodium extensions
 # Note: Code Spell Check and Markdown preview are in base image.
-RUN codium --install-extension vue.volar \
-  && codium --install-extension dbaeumer.vscode-eslint \
-  && codium --install-extension esbenp.prettier-vscode \
-  && codium --install-extension timonwong.shellcheck \
-  && codium --install-extension mkhl.shfmt \
-  && codium --install-extension errata-ai.vale-server
+# RUN codium --install-extension vue.volar \
+#   && codium --install-extension dbaeumer.vscode-eslint \
+#   && codium --install-extension esbenp.prettier-vscode \
+#   && codium --install-extension timonwong.shellcheck \
+#   && codium --install-extension mkhl.shfmt
 
 # Install shfmt - shell script formattter.
 RUN curl -sS https://webinstall.dev/shfmt | bash

--- a/fd2dev/Dockerfile
+++ b/fd2dev/Dockerfile
@@ -49,6 +49,11 @@ COPY gh.bash .
 RUN ./gh.bash \
   && rm gh.bash
 
+# Install the vale prose linter
+COPY vale.bash .
+RUN ./vale.bash \
+  && rm vale.bash
+
 # Modify the default umask for the sytsem so that when files
 # or directories are created the group has RW permisison as
 # well as the owner.  That will ensure tha that any new files
@@ -67,7 +72,8 @@ RUN codium --install-extension vue.volar \
   && codium --install-extension dbaeumer.vscode-eslint \
   && codium --install-extension esbenp.prettier-vscode \
   && codium --install-extension timonwong.shellcheck \
-  && codium --install-extension mkhl.shfmt
+  && codium --install-extension mkhl.shfmt \
+  && codium --install-extension errata-ai.vale-server
 
 # Install shfmt - shell script formattter.
 RUN curl -sS https://webinstall.dev/shfmt | bash

--- a/fd2dev/docker.bash
+++ b/fd2dev/docker.bash
@@ -18,4 +18,5 @@ apt install -y --no-install-recommends \
     docker-ce \
     docker-ce-cli \
     containerd.io \
-    docker-compose-plugin
+    docker-compose-plugin \
+    docker-buildx-plugin

--- a/fd2dev/gh.bash
+++ b/fd2dev/gh.bash
@@ -6,9 +6,10 @@
 # Approach from:
 # https://github.com/cli/cli/blob/trunk/docs/install_linux.md
 
-type -p curl >/dev/null || ( apt update && sudo apt install curl -y)
-curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg \
-&& chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg \
-&& echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | tee /etc/apt/sources.list.d/github-cli.list > /dev/null \
+(type -p wget >/dev/null || (sudo apt update && sudo apt-get install wget -y)) \
+&& mkdir -p -m 755 /etc/apt/keyrings \
+&& wget -qO- https://cli.github.com/packages/githubcli-archive-keyring.gpg | sudo tee /etc/apt/keyrings/githubcli-archive-keyring.gpg > /dev/null \
+&& chmod go+r /etc/apt/keyrings/githubcli-archive-keyring.gpg \
+&& echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null \
 && apt update \
 && apt install gh -y

--- a/fd2dev/repo.txt
+++ b/fd2dev/repo.txt
@@ -1,1 +1,1 @@
-fd2dev:fd2.8
+fd2dev:fd2.9

--- a/fd2dev/vale.bash
+++ b/fd2dev/vale.bash
@@ -1,0 +1,17 @@
+cd /var/tmp
+
+ARCH=$(dpkg --print-architecture)
+VER="3.4.1"
+
+if [ "$ARCH" = "arm64" ]; then
+    VALE_FILE=vale_"$VER"_Linux_arm64.tar.gz
+else
+    VALE_FILE=vale_"$VER"_Linux_64-bit.tar.gz 
+fi
+
+wget https://github.com/errata-ai/vale/releases/download/v"$VER"/"$VALE_FILE"
+mkdir "vale"
+tar -xvzf "$VALE_FILE" -C vale
+cp vale/vale /usr/local/bin
+rm "$VALE_FILE"
+rm -rf vale


### PR DESCRIPTION
This PR adds the vale linter binary to the image.

In addition it:
- Updates to the latest Codium
- Does not pre-install codium extensions because they break the docker build for multi-architecture image.
- adds a -p flag to the build script so that can build the multi-architecture image without pushing during testing.
- ensures that the build runs in the dev environemnt.